### PR TITLE
Run the build and test stack workflow EVERYDAY instead of weekly

### DIFF
--- a/.github/workflows/build-and-test-stack.yml
+++ b/.github/workflows/build-and-test-stack.yml
@@ -3,8 +3,8 @@ name: Build and Test Stack
 on:
   workflow_dispatch: { }
   schedule:
-    # Every Sunday at 1:00 AM
-    - cron: '0 1 * * 0'
+    # Everyday at 1:00 AM
+    - cron: '0 1 * * *'
   push:
     branches: [ main ]
     paths:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Run the build-and-test-stack workflow everyday at 1:00 AM instead of weekly on Sundays. This (along with PRs on the base and tiny stack also) resolves https://github.com/paketo-buildpacks/stacks/issues/75.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Will better protect against missing dependency updates that aren't associated with a USN.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
