### PR TITLE
Fix workflow error trying to download the usns list that is > 1MB

### DIFF
--- a/.github/workflows/check-usns.yml
+++ b/.github/workflows/check-usns.yml
@@ -18,8 +18,12 @@ jobs:
 
     - name: Get USN List
       run: |
+        file_sha="$(curl -sL --fail -u 'paketo-bot:${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}' \
+          api.github.com/repos/paketo-buildpacks/stack-usns/git/trees/main | \
+          jq -r '.tree[] | select(.path == "usns") | .sha')"
+
         curl -sL --fail -u 'paketo-bot:${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}' \
-          api.github.com/repos/paketo-buildpacks/stack-usns/contents/usns | \
+          api.github.com/repos/paketo-buildpacks/stack-usns/git/blobs/${file_sha} | \
           jq -r '.content' | base64 --decode > full-usn-list
 
     - name: Update USNs


### PR DESCRIPTION
## Summary
The [`usns`](https://github.com/paketo-buildpacks/stack-usns/blob/main/usns) file exceeded the 1MB limit of the [Github Get Repo Content API](https://docs.github.com/rest/reference/repos#get-repository-content).

I updated the workflow to obtain the full `usns` list using [Github Get Blob API ](https://docs.github.com/en/rest/reference/git#get-a-blob).

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
