### PR TITLE
Fix build-and-test-stack workflow error trying to download the usns

### DIFF
--- a/.github/workflows/build-and-test-stack.yml
+++ b/.github/workflows/build-and-test-stack.yml
@@ -150,9 +150,14 @@ jobs:
       - name: Get USN List
         id: get-usns
         run: |
+          file_sha="$(curl -sL --fail -u 'paketo-bot:${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}' \
+            api.github.com/repos/paketo-buildpacks/stack-usns/git/trees/main | \
+            jq -r '.tree[] | select(.path == "usns") | .sha')"
+
           curl -sL --fail -u 'paketo-bot:${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}' \
-            api.github.com/repos/paketo-buildpacks/stack-usns/contents/usns | \
+            api.github.com/repos/paketo-buildpacks/stack-usns/git/blobs/${file_sha} | \
             jq -r '.content' | base64 --decode > full-usn-list
+
           echo "::set-output name=usn_path::full-usn-list"
 
       - name: Generate receipt diffs


### PR DESCRIPTION
The same problem as #108  . `build-and-test-stack` workflow also downloads the USNs file.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
